### PR TITLE
Add Claude Code workflow for @claude mentions

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -1,0 +1,41 @@
+name: Claude Code
+
+# Triggers Claude on @claude mentions in issues, PR comments, and reviews.
+# Set up:
+#   1. Install the Claude GitHub App: https://github.com/apps/claude
+#   2. Add an ANTHROPIC_API_KEY repository secret
+#      (Settings → Secrets and variables → Actions → New repository secret)
+
+on:
+  issue_comment:
+    types: [created]
+  pull_request_review_comment:
+    types: [created]
+  pull_request_review:
+    types: [submitted]
+  issues:
+    types: [opened, assigned]
+
+jobs:
+  claude:
+    if: |
+      (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude')) ||
+      (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude')) ||
+      (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@claude')) ||
+      (github.event_name == 'issues' && (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude')))
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+      issues: write
+      id-token: write
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 1
+
+      - name: Run Claude Code
+        uses: anthropics/claude-code-action@beta
+        with:
+          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}

--- a/README.md
+++ b/README.md
@@ -66,6 +66,15 @@ That's it. No npm install, no build step.
 
 Plain HTML, CSS, vanilla JS. Zero dependencies. Hosted on GitHub Pages.
 
+## Issue triage with Claude
+
+This repo has a workflow at `.github/workflows/claude.yml` that lets you summon Claude on demand. To enable:
+
+1. Install the [Claude GitHub App](https://github.com/apps/claude) on this repo.
+2. Add an `ANTHROPIC_API_KEY` repository secret (Settings → Secrets and variables → Actions).
+
+Once enabled, mention `@claude` in an issue body, issue title, PR comment, or review comment, and Claude will investigate and push fixes as needed. Works from the GitHub mobile app too.
+
 ## License
 
 MIT


### PR DESCRIPTION
## Summary

Adds `.github/workflows/claude.yml` so contributors (including you, from the mobile app) can summon Claude by mentioning `@claude` in:

- An issue body or title
- An issue comment
- A PR comment or review comment

When triggered, Claude investigates, can push fixes to a branch, and opens PRs as needed.

README gets a short "Issue triage with Claude" section explaining the two prerequisites:
1. Install the [Claude GitHub App](https://github.com/apps/claude) on the repo
2. Add an `ANTHROPIC_API_KEY` repository secret (Settings → Secrets and variables → Actions)

## Test plan

After merging:
- [ ] Install the Claude GitHub App on the repo
- [ ] Add `ANTHROPIC_API_KEY` as a repo secret
- [ ] Open a test issue with body "`@claude` what files exist in `js/api/`?"
- [ ] Confirm a workflow run kicks off and Claude replies in the issue
- [ ] Test from mobile: comment "`@claude` something" on this PR, confirm response

## Notes

- The action runs only when `@claude` is in the body — no idle billing on every issue/PR event.
- Permissions are scoped to `contents`, `pull-requests`, `issues`, and `id-token` (the standard set the action requires).
- Uses the `@beta` tag of `anthropics/claude-code-action`, which is the current canonical entry point.

https://claude.ai/code/session_01PPXeDBPC3xF13UasSxFfeL

---
_Generated by [Claude Code](https://claude.ai/code/session_01PPXeDBPC3xF13UasSxFfeL)_