### PR TITLE
Reject Open Food Facts items with French/Spanish names

### DIFF
--- a/js/api/openfoodfacts.js
+++ b/js/api/openfoodfacts.js
@@ -1,10 +1,10 @@
 // Open Food Facts — packaged grocery items, no auth required
 //
-// Uses the v2 search API (faster + more stable than legacy /cgi/search.pl).
-// Restricts results to English-language products via a server-side
-// languages_tags filter, and only emits items that have an explicit
-// product_name_en or generic_name_en — older multilingual fallbacks let
-// French/Spanish names through.
+// Uses the v2 search API. OFF's data quality is uneven: many products store
+// French or Spanish text in their `product_name_en` field, and the server-side
+// language filter doesn't reliably exclude them. So we filter twice on the
+// client: (1) require `en:english` in `languages_tags`, (2) reject names that
+// match unambiguous French/Spanish stop-words or food words.
 (function () {
   'use strict';
 
@@ -15,7 +15,26 @@
     'brands',
     'nutriments',
     'code',
+    'languages_tags',
   ].join(',');
+
+  // Whole-word matches only. These are unambiguous in a food-product name —
+  // English never uses "blanc/poulet/sans/pollo/pechuga" etc. as ordinary
+  // vocabulary, even when borrowing French cuisine terms.
+  const NON_ENGLISH_RE = new RegExp(
+    '\\b(' + [
+      // French
+      'blanc', 'noir', 'rouge', 'jaune',
+      'sans', 'avec', 'pour', 'aux', 'rôti', 'tranches?', 'broche',
+      'poulet', 'boeuf', 'bœuf', 'porc', 'agneau', 'jambon', 'saumon',
+      'fromage', 'beurre', 'lait',
+      // Spanish
+      'pollo', 'pescado', 'cerdo', 'pechuga', 'tiras', 'filete', 'rebanadas?',
+      'queso', 'leche', 'mantequilla', 'manzana', 'fresa',
+      'del', 'los', 'las', 'sin', 'con',
+    ].join('|') + ')\\b',
+    'i'
+  );
 
   function fetchWithTimeout(url, opts = {}, ms = 12000) {
     return Promise.race([
@@ -27,11 +46,14 @@
   }
 
   function pickEnglishName(product) {
-    if (product.product_name_en && product.product_name_en.trim()) {
-      return product.product_name_en.trim();
-    }
-    if (product.generic_name_en && product.generic_name_en.trim()) {
-      return product.generic_name_en.trim();
+    const tags = product.languages_tags || [];
+    if (!tags.includes('en:english')) return null;
+    const candidates = [product.product_name_en, product.generic_name_en];
+    for (const c of candidates) {
+      const trimmed = (c || '').trim();
+      if (!trimmed) continue;
+      if (NON_ENGLISH_RE.test(trimmed)) continue;
+      return trimmed;
     }
     return null;
   }

--- a/js/storage.js
+++ b/js/storage.js
@@ -5,7 +5,7 @@
 
   const ENTRIES_KEY = 'tally.entries.v1';
   const SETTINGS_KEY = 'tally.settings.v1';
-  const CACHE_KEY = 'tally.cache.v2';
+  const CACHE_KEY = 'tally.cache.v3';
   const CACHE_TTL_MS = 7 * 24 * 60 * 60 * 1000; // 7 days
 
   const DEFAULT_SETTINGS = {


### PR DESCRIPTION
## Summary

Follow-up to #6. The previous fix wasn't enough — the live site still shows seven French/Spanish results for "chicken breast" because OFF's data quality is worse than expected:

- Many products store their French/Spanish name verbatim in the `product_name_en` field (e.g. `Blanc de Poulet Nature Sans Nitrite` was returned with that text in `product_name_en`)
- The server-side `languages_tags=en:english` filter doesn't reliably exclude them

Add a two-layer client-side defense:

1. **Per-product language tag check.** Re-add `languages_tags` to the requested fields and require `en:english` to be present in each product's tags before considering it.
2. **Heuristic name check.** Reject names containing unambiguous French/Spanish food vocabulary (`blanc`, `poulet`, `sans`, `rôti`, `tranches`, `pollo`, `pechuga`, `tiras`, etc.). I confirmed via a unit-style script that all 7 leaks reported on the live site are rejected, while English loanword names like `Filet Mignon` and `Crème brûlée` still pass.

Bump cache to `v3` so users whose `v2` cache holds the French results get a fresh search.

## Test plan

- [ ] Hard-refresh the live site, search `chicken breast` → Open Food Facts group no longer shows `Blanc de Poulet`, `Tiras de pechuga de pollo`, etc.
- [ ] Search `nutella` → branded English-language entries still appear with calories
- [ ] Search `crème brûlée` → English/loanword items still come through (not over-filtered)
- [ ] Settings → Test Connections → Open Food Facts still reports `connected`

---
_Generated by [Claude Code](https://claude.ai/code/session_014XPkFPsDTxAzp4vLhwgSjx)_