### PR TITLE
Cache-bust JS/CSS so deploys take effect immediately

### DIFF
--- a/index.html
+++ b/index.html
@@ -7,7 +7,7 @@
 <link rel="preconnect" href="https://fonts.googleapis.com">
 <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
 <link href="https://fonts.googleapis.com/css2?family=Fraunces:ital,opsz,wght@0,9..144,400;0,9..144,500;0,9..144,700;1,9..144,400&family=JetBrains+Mono:wght@400;500&display=swap" rel="stylesheet">
-<link rel="stylesheet" href="styles.css">
+<link rel="stylesheet" href="styles.css?v=3">
 </head>
 <body>
 <div class="frame">
@@ -114,16 +114,19 @@
 
 <div class="toast" id="toast"></div>
 
-<script src="js/storage.js"></script>
-<script src="js/api/usda.js"></script>
-<script src="js/api/nutritionix.js"></script>
-<script src="js/api/openfoodfacts.js"></script>
-<script src="js/api/aggregator.js"></script>
-<script src="js/ui/chart.js"></script>
-<script src="js/ui/settings.js"></script>
-<script src="js/ui/compose.js"></script>
-<script src="js/ui/log.js"></script>
-<script src="js/ui/history.js"></script>
-<script src="js/app.js"></script>
+<!-- Bump ?v= on every deploy so GitHub Pages' CDN serves fresh JS instead of
+     stale cached copies. Browsers treat the query string as part of the URL,
+     so a new value forces a re-fetch even when index.html is still cached. -->
+<script src="js/storage.js?v=3"></script>
+<script src="js/api/usda.js?v=3"></script>
+<script src="js/api/nutritionix.js?v=3"></script>
+<script src="js/api/openfoodfacts.js?v=3"></script>
+<script src="js/api/aggregator.js?v=3"></script>
+<script src="js/ui/chart.js?v=3"></script>
+<script src="js/ui/settings.js?v=3"></script>
+<script src="js/ui/compose.js?v=3"></script>
+<script src="js/ui/log.js?v=3"></script>
+<script src="js/ui/history.js?v=3"></script>
+<script src="js/app.js?v=3"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary

After PR #7 merged, the live site kept showing the same 7 French/Spanish results — even in a private tab — because GitHub Pages' Fastly CDN held stale `index.html` and JS files at the edge for ~15+ minutes despite the source on `main` having the new code.

Add a `?v=3` query string to every `<script>` and `<link rel="stylesheet">` reference. Browsers (and the CDN) treat the query string as part of the URL, so changing the version forces a fresh fetch even when the file content didn't change. Bumping it on each deploy means stale-cache-induced ghost bugs go away.

Once this PR merges and the new `index.html` is served, the JS will be re-fetched fresh and the language filter from #7 will actually run.

## Convention going forward

When making a deploy that needs to take effect immediately, bump `?v=3` → `?v=4` (or whatever) in `index.html`. Eleven references, all share the same number — find/replace `?v=3` works.

## Test plan

- [ ] Wait for Pages to publish, then hard-refresh the live site (Private mode for certainty)
- [ ] DevTools/Network → confirm script URLs include `?v=3`
- [ ] Search "chicken breast" → Open Food Facts no longer returns `Blanc de Poulet`, `Tiras de pechuga`, etc.

---
_Generated by [Claude Code](https://claude.ai/code/session_014XPkFPsDTxAzp4vLhwgSjx)_